### PR TITLE
Use JDK socket communication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,10 @@
             </exclusions>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.github.hypfvieh/dbus-java-transport-jnr-unixsocket -->
+        <!-- https://mvnrepository.com/artifact/com.github.hypfvieh/dbus-java-transport-native-unixsocket -->
         <dependency>
             <groupId>com.github.hypfvieh</groupId>
-            <artifactId>dbus-java-transport-jnr-unixsocket</artifactId>
+            <artifactId>dbus-java-transport-native-unixsocket</artifactId>
             <version>${dbus-java.version}</version>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Removes transitive JNR dependency by switching to `dbus-java-transport-native-unixsocket` library.

Since JDK 16, communication via unix socket is supported natively, a third party library is not needed. See also https://github.com/hypfvieh/dbus-java/issues/145#issuecomment-914387726.

Maybe this can be released as a 1.8.0?