### PR TITLE
[WIP] Add initial CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 20]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install packages on linux
+        run: >
+          sudo apt-get -qq install -y --no-install-recommends dbus-x11 gnome-keyring dbus libdbus-glib-1-dev libsecret-tools
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
+      - name: Maven Install
+        run: |
+          xvfb-run --auto-servernum bash <<EOF
+            export $(dbus-launch)
+            eval "$(echo '\n' | gnome-keyring-daemon --unlock)"
+            mvn --batch-mode --update-snapshots -Dgpg.skip=true install
+          EOF


### PR DESCRIPTION
Tries to add a CI check.

The CI, however, reports the following:

```
[main] INFO org.freedesktop.dbus.connections.transports.TransportBuilder - Using transport dbus-java-transport-native-unixsocket to connect to unix:abstract=/tmp/dbus-UCh7J6wNIW,guid=d731f279cc36217b8576350a64f7963d
[main] ERROR org.freedesktop.dbus.connections.transports.TransportBuilder - Could not initialize transport
org.freedesktop.dbus.exceptions.TransportConfigurationException: Native unix socket url has to specify 'path'
```

I checked the JDK source - and they don't have support for `abstract`.

The [JEP-380](https://openjdk.org/jeps/380) also tells so: ![image](https://github.com/swiesend/secret-service/assets/1366654/8f24acb4-db1a-467e-ad2e-1e38d9c38c45)

DBUS always seems to create an `abstract` socket, **doesn't it**? -- https://unix.stackexchange.com/q/184964/18033. I wonder how `1.8.1-jdk17` can ever work

---

1.7.0 works OKish in the CI - see https://github.com/koppor/secret-service/actions/runs/6089898442/job/16523646209

    Tests run: 84, Failures: 2, Errors: 50, Skipped: 17

---

1.8.0 also works OKish in the CI - see https://github.com/koppor/secret-service/actions/runs/6089928817/job/16523740558

    [main] INFO org.freedesktop.dbus.connections.transports.TransportBuilder - Using transport dbus-java-transport-jnr-unixsocket to connect to unix:abstract=/tmp/dbus-lCpu1q0RLz,guid=b7c9c44be5207b674db7da3364f79cde

