### PR TITLE
Bump: dbus-java 4.3.1 -> 5.2.0

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -80,9 +80,10 @@ src/test/java/
 
 ### D-Bus Message Handling
 
-- `MessageHandler` constructs `MethodCall` messages directly using dbus-java's public constructor API.
-- dbus-java 4.x is pinned at 4.3.1. The 5.x upgrade is deferred because 5.2.0 made all `MethodCall` constructors protected with no public alternative, requiring reflection + `--add-opens` which is not acceptable for library consumers on strict JPMS.
-- Error responses are checked via `instanceof org.freedesktop.dbus.errors.Error` (4.x package location; moved to `messages.Error` in 5.x).
+- `MessageHandler` constructs `MethodCall` messages via `connection.getMessageFactory().createMethodCall(...)`. The direct `new MethodCall(...)` constructor was made non-public in dbus-java 5.x; `MessageFactory` is the supported public alternative and works without reflection or `--add-opens`.
+- dbus-java is pinned at 5.2.0. This resolves classpath collisions (e.g. issue #51) when other libraries on the classpath ship a newer dbus-java that no longer provides the 4.x public `MethodCall` constructor.
+- Error responses are checked via `instanceof org.freedesktop.dbus.messages.Error` (the class moved from `org.freedesktop.dbus.errors.Error` in 4.x).
+- D-Bus byte arrays (signature `ay`) may be unmarshalled as either `byte[]` or `List<Byte>` in dbus-java 5.1.0+. `TransportEncryption.toBytes(Object)` normalizes both representations to `byte[]`.
 
 ### JPMS Module
 
@@ -105,8 +106,8 @@ module de.swiesend.secretservice {
 
 | Dependency | Version | Purpose |
 |---|---|---|
-| `dbus-java-core` | 4.3.1 | D-Bus communication |
-| `dbus-java-transport-native-unixsocket` | 4.3.1 | Unix socket transport |
+| `dbus-java-core` | 5.2.0 | D-Bus communication |
+| `dbus-java-transport-native-unixsocket` | 5.2.0 | Unix socket transport |
 | `hkdf` (at.favre.lib) | 2.0.0 | HMAC-based key derivation |
 | `slf4j-api` | 2.0.17 | Logging |
 | `junit-jupiter` | 5.10.5 | Testing (test scope) |

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -83,7 +83,7 @@ src/test/java/
 - `MessageHandler` constructs `MethodCall` messages via `connection.getMessageFactory().createMethodCall(...)`. The direct `new MethodCall(...)` constructor was made non-public in dbus-java 5.x; `MessageFactory` is the supported public alternative and works without reflection or `--add-opens`.
 - dbus-java is pinned at 5.2.0. This resolves classpath collisions (e.g. issue #51) when other libraries on the classpath ship a newer dbus-java that no longer provides the 4.x public `MethodCall` constructor.
 - Error responses are checked via `instanceof org.freedesktop.dbus.messages.Error` (the class moved from `org.freedesktop.dbus.errors.Error` in 4.x).
-- D-Bus byte arrays (signature `ay`) may be unmarshalled as either `byte[]` or `List<Byte>` in dbus-java 5.1.0+. `TransportEncryption.toBytes(Object)` normalizes both representations to `byte[]`.
+- D-Bus byte arrays (signature `ay`) may be unmarshalled as either `byte[]` or `List<Byte>` in dbus-java 5.1.0+. `Static.Utils.toByteArray(Object)` normalizes both representations to `byte[]`.
 
 ### JPMS Module
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- 3rd party dependencies -->
         <hkdf.version>2.0.0</hkdf.version>
-        <dbus-java.version>4.3.1</dbus-java.version>
+        <dbus-java.version>5.2.0</dbus-java.version>
         <slf4j.version>2.0.17</slf4j.version>
 
         <!-- test dependencies -->

--- a/src/main/java/de/swiesend/secretservice/Service.java
+++ b/src/main/java/de/swiesend/secretservice/Service.java
@@ -103,7 +103,7 @@ public class Service extends Messaging implements de.swiesend.secretservice.inte
     @Override
     public Optional<List<DBusPath>> getCollections() {
         return getProperty("Collections").flatMap(variant ->
-                variant == null ? Optional.empty() : Optional.ofNullable((ArrayList<DBusPath>) variant.getValue())
+                variant == null ? Optional.empty() : Optional.ofNullable((List<DBusPath>) variant.getValue())
         );
     }
 

--- a/src/main/java/de/swiesend/secretservice/Static.java
+++ b/src/main/java/de/swiesend/secretservice/Static.java
@@ -207,6 +207,27 @@ public class Static {
         public static boolean isNullOrEmpty(Object[] objects) {
             return objects == null || objects.length == 0;
         }
+
+        // dbus-java 5.1.0+ may unmarshal `ay` as either byte[] or List<Byte>; normalize to byte[].
+        @SuppressWarnings("unchecked")
+        public static byte[] toByteArray(Object value) {
+            if (value == null) {
+                throw new IllegalStateException("Unexpected D-Bus byte array representation: null");
+            }
+            if (value instanceof byte[]) {
+                return (byte[]) value;
+            }
+            if (value instanceof List) {
+                List<Byte> byteList = (List<Byte>) value;
+                byte[] result = new byte[byteList.size()];
+                for (int i = 0; i < byteList.size(); i++) {
+                    result[i] = byteList.get(i);
+                }
+                return result;
+            }
+            throw new IllegalStateException(
+                    "Unexpected D-Bus byte array representation: " + value.getClass().getName());
+        }
     }
 
     /**

--- a/src/main/java/de/swiesend/secretservice/TransportEncryption.java
+++ b/src/main/java/de/swiesend/secretservice/TransportEncryption.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
+import java.util.List;
 import java.util.Optional;
 
 public class TransportEncryption implements AutoCloseable {
@@ -121,16 +122,34 @@ public class TransportEncryption implements AutoCloseable {
             // open session with "Client DH pub key as an array of bytes" without prime or generator
             return service.openSession(
                     Static.Algorithm.DH_IETF1024_SHA256_AES128_CBC_PKCS7,
-                    new Variant(ya.toByteArray())
+                    new Variant<>(ya.toByteArray())
             ).flatMap(pair -> {
                 // transform peer's raw Y to a public key
-                yb = pair.a.getValue();
+                yb = toBytes(pair.a.getValue());
 
                 DBusPath sessionPath = pair.b;
                 session = new Session(sessionPath, service);
                 return Optional.of(new OpenedSession());
             });
         }
+    }
+
+    // dbus-java 5.1.0+ may unmarshal `ay` as either byte[] or List<Byte>; normalize to byte[].
+    @SuppressWarnings("unchecked")
+    private static byte[] toBytes(Object value) {
+        if (value instanceof byte[]) {
+            return (byte[]) value;
+        }
+        if (value instanceof List) {
+            List<Byte> byteList = (List<Byte>) value;
+            byte[] result = new byte[byteList.size()];
+            for (int i = 0; i < byteList.size(); i++) {
+                result[i] = byteList.get(i);
+            }
+            return result;
+        }
+        throw new IllegalStateException(
+                "Unexpected D-Bus byte array representation: " + (value == null ? "null" : value.getClass().getName()));
     }
 
     public class OpenedSession {

--- a/src/main/java/de/swiesend/secretservice/TransportEncryption.java
+++ b/src/main/java/de/swiesend/secretservice/TransportEncryption.java
@@ -21,7 +21,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
-import java.util.List;
 import java.util.Optional;
 
 public class TransportEncryption implements AutoCloseable {
@@ -125,31 +124,13 @@ public class TransportEncryption implements AutoCloseable {
                     new Variant<>(ya.toByteArray())
             ).flatMap(pair -> {
                 // transform peer's raw Y to a public key
-                yb = toBytes(pair.a.getValue());
+                yb = Static.Utils.toByteArray(pair.a.getValue());
 
                 DBusPath sessionPath = pair.b;
                 session = new Session(sessionPath, service);
                 return Optional.of(new OpenedSession());
             });
         }
-    }
-
-    // dbus-java 5.1.0+ may unmarshal `ay` as either byte[] or List<Byte>; normalize to byte[].
-    @SuppressWarnings("unchecked")
-    private static byte[] toBytes(Object value) {
-        if (value instanceof byte[]) {
-            return (byte[]) value;
-        }
-        if (value instanceof List) {
-            List<Byte> byteList = (List<Byte>) value;
-            byte[] result = new byte[byteList.size()];
-            for (int i = 0; i < byteList.size(); i++) {
-                result[i] = byteList.get(i);
-            }
-            return result;
-        }
-        throw new IllegalStateException(
-                "Unexpected D-Bus byte array representation: " + (value == null ? "null" : value.getClass().getName()));
     }
 
     public class OpenedSession {

--- a/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
+++ b/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
@@ -95,7 +95,6 @@ public class MessageHandler {
                         }
                         return Optional.empty();
                     case "org.freedesktop.DBus.Local.Disconnected":
-                    case "org.freedesktop.dbus.exceptions.DBusExecutionException":
                     case "org.freedesktop.dbus.exceptions.FatalDBusException":
                     case "org.freedesktop.dbus.exceptions.NotConnected":
                         if (log.isDebugEnabled()) log.debug(error);

--- a/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
+++ b/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
@@ -3,6 +3,7 @@ package de.swiesend.secretservice.handlers;
 import de.swiesend.secretservice.Static;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.messages.MessageFactory;
 import org.freedesktop.dbus.messages.MethodCall;
 import org.freedesktop.dbus.types.Variant;
 import org.slf4j.Logger;
@@ -31,7 +32,8 @@ public class MessageHandler {
 
     public Optional<Object[]> send(String service, String path, String iface, String method, String signature, Object... args) {
         try {
-            org.freedesktop.dbus.messages.Message message = new MethodCall(
+            MessageFactory msgFactory = connection.getMessageFactory();
+            org.freedesktop.dbus.messages.Message message = msgFactory.createMethodCall(
                     service,
                     path,
                     iface,
@@ -53,7 +55,7 @@ public class MessageHandler {
                     log.debug("Response parameters for method " + iface + "/" + method + ": " + Arrays.deepToString(parameters));
             }
 
-            if (response instanceof org.freedesktop.dbus.errors.Error) {
+            if (response instanceof org.freedesktop.dbus.messages.Error) {
                 String error = response.getName();
                 switch (error) {
                     case "org.freedesktop.Secret.Error.NoSession":
@@ -93,6 +95,7 @@ public class MessageHandler {
                         }
                         return Optional.empty();
                     case "org.freedesktop.DBus.Local.Disconnected":
+                    case "org.freedesktop.dbus.exceptions.DBusExecutionException":
                     case "org.freedesktop.dbus.exceptions.FatalDBusException":
                     case "org.freedesktop.dbus.exceptions.NotConnected":
                         if (log.isDebugEnabled()) log.debug(error);

--- a/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
+++ b/src/main/java/de/swiesend/secretservice/handlers/MessageHandler.java
@@ -95,8 +95,6 @@ public class MessageHandler {
                         }
                         return Optional.empty();
                     case "org.freedesktop.DBus.Local.Disconnected":
-                    case "org.freedesktop.dbus.exceptions.FatalDBusException":
-                    case "org.freedesktop.dbus.exceptions.NotConnected":
                         if (log.isDebugEnabled()) log.debug(error);
                         return Optional.empty();
                     default:
@@ -110,8 +108,12 @@ public class MessageHandler {
                     return Optional.ofNullable(parameters);
                 }
             }
+        } catch (org.freedesktop.dbus.exceptions.FatalDBusException e) {
+            if (log.isDebugEnabled()) log.debug(e.getClass().getName(), e);
         } catch (DBusException e) {
             log.error("Unexpected D-Bus response: ", e);
+        } catch (org.freedesktop.dbus.exceptions.NotConnected e) {
+            if (log.isDebugEnabled()) log.debug(e.getClass().getName(), e);
         } catch (RuntimeException e) {
             log.error("Unexpected: ", e);
         }

--- a/src/test/java/de/swiesend/secretservice/integration/IntegrationTest.java
+++ b/src/test/java/de/swiesend/secretservice/integration/IntegrationTest.java
@@ -101,7 +101,7 @@ public class IntegrationTest {
         Item item = new Item(itemPath, service);
         Secret actual = item.getSecret(session.getPath()).get();
 
-        assertEquals(encrypted.getSession(), actual.getSession());
+        assertEquals(encrypted.getSession().getPath(), actual.getSession().getPath());
         assertEquals(encrypted.getContentType(), actual.getContentType());
 
         decrypted = encryptedSession.decrypt(actual).get();

--- a/src/test/java/de/swiesend/secretservice/integration/ServiceTest.java
+++ b/src/test/java/de/swiesend/secretservice/integration/ServiceTest.java
@@ -37,7 +37,7 @@ public class ServiceTest {
     public void openSession() {
         context.ensureService();
 
-        Optional<Pair<Variant<byte[]>, DBusPath>> response = context.service.openSession(Static.Algorithm.PLAIN, new Variant(""));
+        Optional<Pair<Variant<byte[]>, DBusPath>> response = context.service.openSession(Static.Algorithm.PLAIN, new Variant<>(""));
         log.info(response.toString());
 
         assertEquals("s", response.get().a.getSig());
@@ -72,10 +72,22 @@ public class ServiceTest {
         assertEquals(128, input.length);
 
         Optional<Pair<Variant<byte[]>, DBusPath>> response = context.service.openSession(
-                Static.Algorithm.DH_IETF1024_SHA256_AES128_CBC_PKCS7, new Variant(input));
+                Static.Algorithm.DH_IETF1024_SHA256_AES128_CBC_PKCS7, new Variant<>(input));
         log.info(response.toString());
 
-        byte[] peerPublicKey = response.get().a.getValue();
+        Object value = response.get().a.getValue();
+        byte[] peerPublicKey;
+        if (value instanceof byte[]) {
+            peerPublicKey = (byte[]) value;
+        } else if (value instanceof List) {
+            List<Byte> byteList = (List<Byte>) value;
+            peerPublicKey = new byte[byteList.size()];
+            for (int i = 0; i < byteList.size(); i++) {
+                peerPublicKey[i] = byteList.get(i);
+            }
+        } else {
+            throw new IllegalStateException("Unexpected value type: " + value.getClass().getName());
+        }
         assertEquals(128, peerPublicKey.length);
 
         DBusPath sessionPath = response.get().b;

--- a/src/test/java/de/swiesend/secretservice/integration/ServiceTest.java
+++ b/src/test/java/de/swiesend/secretservice/integration/ServiceTest.java
@@ -75,19 +75,7 @@ public class ServiceTest {
                 Static.Algorithm.DH_IETF1024_SHA256_AES128_CBC_PKCS7, new Variant<>(input));
         log.info(response.toString());
 
-        Object value = response.get().a.getValue();
-        byte[] peerPublicKey;
-        if (value instanceof byte[]) {
-            peerPublicKey = (byte[]) value;
-        } else if (value instanceof List) {
-            List<Byte> byteList = (List<Byte>) value;
-            peerPublicKey = new byte[byteList.size()];
-            for (int i = 0; i < byteList.size(); i++) {
-                peerPublicKey[i] = byteList.get(i);
-            }
-        } else {
-            throw new IllegalStateException("Unexpected value type: " + value.getClass().getName());
-        }
+        byte[] peerPublicKey = Static.Utils.toByteArray(response.get().a.getValue());
         assertEquals(128, peerPublicKey.length);
 
         DBusPath sessionPath = response.get().b;

--- a/src/test/java/de/swiesend/secretservice/integration/keyring/InternalUnsupportedGuiltRiddenInterfaceTest.java
+++ b/src/test/java/de/swiesend/secretservice/integration/keyring/InternalUnsupportedGuiltRiddenInterfaceTest.java
@@ -36,7 +36,7 @@ public class InternalUnsupportedGuiltRiddenInterfaceTest {
     public void beforeEach() throws DBusException {
         connection = DBusConnectionBuilder.forSessionBus().withShared(false).build();
         service = new Service(connection);
-        Pair<Variant<byte[]>, DBusPath> pair = service.openSession(Static.Algorithm.PLAIN, new Variant("")).get();
+        Pair<Variant<byte[]>, DBusPath> pair = service.openSession(Static.Algorithm.PLAIN, new Variant<>("")).get();
         DBusPath sessionPath = pair.b;
         iugri = new InternalUnsupportedGuiltRiddenInterface(service);
         original = new Secret(sessionPath, "".getBytes(), "test".getBytes());
@@ -57,7 +57,7 @@ public class InternalUnsupportedGuiltRiddenInterfaceTest {
         List<String> cs = Static.Convert.toStrings(collections);
         if (!cs.contains("/org/freedesktop/secrets/collection/test")) {
             HashMap<String, Variant> properties = new HashMap<>();
-            properties.put("org.freedesktop.Secret.Collection.Label", new Variant("test"));
+            properties.put("org.freedesktop.Secret.Collection.Label", new Variant<>("test"));
             iugri.createWithMasterPassword(properties, original);
             Thread.sleep(100L);
         }
@@ -95,7 +95,7 @@ public class InternalUnsupportedGuiltRiddenInterfaceTest {
         }
 
         HashMap<String, Variant> properties = new HashMap<>();
-        properties.put("org.freedesktop.Secret.Collection.Label", new Variant("test"));
+        properties.put("org.freedesktop.Secret.Collection.Label", new Variant<>("test"));
         iugri.createWithMasterPassword(properties, original);
         Thread.sleep(100L); // await signal: Service.CollectionCreated
 


### PR DESCRIPTION
## Summary

Bumps `dbus-java` from 4.3.1 to 5.2.0 (the latest stable release, Dec 2025) and adopts the supported public APIs that replace the constructors/types removed in 5.x.

The motivating bug is #51: when another library on the classpath ships dbus-java 5.x, our `new MethodCall(...)` call site fails with `NoSuchMethodError` because the public 4.x constructor is no longer available. PRs #48 and #50 demonstrated the migration path; this PR is that migration carried forward to 5.2.0 with the cleanup feedback applied.

## Changes

### Production code

- **`pom.xml`** — `dbus-java.version` 4.3.1 → 5.2.0.
- **`handlers/MessageHandler`**
  - Constructs `MethodCall` via `connection.getMessageFactory().createMethodCall(...)` instead of the now non-public constructor (issue #51).
  - Checks errors via `instanceof org.freedesktop.dbus.messages.Error` (the class moved out of `org.freedesktop.dbus.errors`).
  - `FatalDBusException` and `NotConnected` are handled in dedicated `catch` clauses ahead of the generic `DBusException` / `RuntimeException` branches, so disconnect conditions stay at `debug` level instead of being demoted to `error`. The dead Java-FQCN cases on the wire-error switch are gone.
- **`TransportEncryption`** — calls a shared `Static.Utils.toByteArray(Object)` helper to normalize `Variant<byte[]>.getValue()` because dbus-java 5.1.0+ may unmarshal `ay` as either `byte[]` or `List<Byte>` depending on resolution.
- **`Service.getCollections()`** — casts to `List<DBusPath>` instead of `ArrayList<DBusPath>` (collection impls changed in 5.1.0).
- **`Static.Utils.toByteArray(Object)`** — new shared helper for `byte[]` / `List<Byte>` normalization with a null-safe error message.

### Tests

- **`ServiceTest.openSessionWithTransportEncryption`** — uses the shared `Static.Utils.toByteArray` helper.
- **`IntegrationTest.testWithTransportEncryption`** — compares `Secret.getSession().getPath()` instead of the `DBusPath` instances (`DBusPath.hashCode/equals` was fixed in 5.1.0).
- All raw `new Variant(...)` call sites switched to `new Variant<>(...)`.

### Docs

- `agents/AGENTS.md` (and the `CLAUDE.md` symlink) refreshed to describe the new `MessageFactory`-based message construction, the moved `messages.Error` class, the pinned 5.2.0 version, and the `Static.Utils.toByteArray` helper.

## Test plan

- [x] `mvn clean compile` succeeds locally.
- [x] `mvn test-compile` succeeds locally.
- [ ] CI integration tests pass (Docker D-Bus mock + gnome-keyring-daemon).

Resolves #51. Inspired by #48 and #50.